### PR TITLE
Handle front matter string results

### DIFF
--- a/src/parsers/matter.js
+++ b/src/parsers/matter.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var q = require('q');
 var util = require('util');
 var fs = require('q-io/fs');
@@ -20,10 +21,13 @@ parsers.register.parser('matter', function(filename, options) {
   return fs
     .read(filename)
     .then(function(data) {
-      return q(parser)
-        .fcall(data)
-        .catch(function() {
-          return {};
-        });
+      var result;
+
+      try { result = parser(data); }
+      catch(e) {}
+
+      return _.isObject(result)
+        ? result
+        : {};
     });
 });

--- a/test/fixtures/weird-matter.md
+++ b/test/fixtures/weird-matter.md
@@ -1,0 +1,5 @@
+---
+foo
+---
+
+This file has a front matter, but not one that we can gather actual data from, it should be ignored.

--- a/test/parsers.matter.test.js
+++ b/test/parsers.matter.test.js
@@ -18,6 +18,13 @@ describe("creep.parsers:matter", function() {
       });
   });
 
+  it("should return an empty object if the parser returns a non-object", function() {
+    return matter(paths.fixtures('weird-matter.md'))
+      .then(function(metadata) {
+        assert.deepEqual(metadata, {});
+      });
+  });
+
   describe("if no matter parser is found for the requested format", function() {
     it("should errback", function() {
       return matter('does/not/matter.js', {matterFormat: 'bleh'})


### PR DESCRIPTION
Yaml front matters can be any valid yaml between `---`s, so `---\nfoo\n--` is a valid yaml front matter. This causes merge errors, since we can't merge a `'foo'` with a `{bar: 'baz'}`.
